### PR TITLE
Opinionated EKS hosts

### DIFF
--- a/examples/eks-nodes/main.tf
+++ b/examples/eks-nodes/main.tf
@@ -39,5 +39,4 @@ module "asg" {
   max_instance_count = 1
   capacity           = "m5.large"
   os_disk_size       = 20
-  eks_version        = "1.24"
 }

--- a/examples/eks-nodes/main.tf
+++ b/examples/eks-nodes/main.tf
@@ -31,12 +31,12 @@ data "duplocloud_tenant" "current" {
 
 module "asg" {
   source = "../../modules/eks-nodes"
-  # version            = "0.0.10"
-  tenant_id          = data.duplocloud_tenant.current.id
-  prefix             = "fun-"
-  instance_count     = 1
-  min_instance_count = 1
-  max_instance_count = 1
-  capacity           = "m5.large"
-  os_disk_size       = 20
+  # version                     = "0.0.10"
+  tenant_id                   = data.duplocloud_tenant.current.id
+  prefix                      = "fun-"
+  instance_count_per_zone     = 1
+  min_instance_count_per_zone = 1
+  max_instance_count_per_zone = 1
+  capacity                    = "m5.large"
+  os_disk_size                = 20
 }

--- a/examples/eks-nodes/main.tf
+++ b/examples/eks-nodes/main.tf
@@ -33,7 +33,7 @@ module "asg" {
   source = "../../modules/eks-nodes"
   # version                     = "0.0.10"
   tenant_id                   = data.duplocloud_tenant.current.id
-  prefix                      = "fun-"
+  prefix                      = "fun"
   instance_count_per_zone     = 1
   min_instance_count_per_zone = 1
   max_instance_count_per_zone = 1

--- a/examples/eks-nodes/main.tftest.hcl
+++ b/examples/eks-nodes/main.tftest.hcl
@@ -2,7 +2,7 @@
 run "make_an_asg" {
   command = apply
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "fun-a"
-    error_message = "friendly_name is not fun-a"
+    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "fun-us-west-2a"
+    error_message = "friendly_name is not fun-us-west-2a"
   }
 }

--- a/modules/eks-nodes/README.md
+++ b/modules/eks-nodes/README.md
@@ -14,13 +14,19 @@ module "nodegroup" {
   version            = "0.0.5"
   tenant_id          = local.tenant_id
   capacity           = var.asg_capacity
-  eks_version        = local.eks_version
   instance_count     = var.asg_instance_count
   min_instance_count = var.asg_min_instance_count
   max_instance_count = var.asg_max_instance_count
   os_disk_size       = var.asg_os_disk_size
 }
 ```
+
+## Deprecated Variables
+
+* `az_list`. One ASG is created for each AZ configured in the [DuploCloud plan](https://docs.duplocloud.com/docs/getting-started/application-focussed-interface/plan).
+* `base_ami_name`.  The EKS AMI is found internally by the `duplocloud_native_host_image` resource.
+* `eks_version`. The EKS version is determined internally by the `duplocloud_native_host_image` resource.
+* `encrypt_disk`. All ASGs are created with encrypted disks.
 
 ## Testing
 

--- a/modules/eks-nodes/README.md
+++ b/modules/eks-nodes/README.md
@@ -1,10 +1,12 @@
-# EKS HA Nodes  
+# EKS HA Nodes
 
-Creates duplocloud EKS hosts for a tenant. This creates an HA setup on at least two zones. The min/max/count is actually multiplied by the amount of zones. So if you have 3 zones and you set min=1, max=3, count=2, you will get 6 hosts. 
+Creates duplocloud EKS hosts for a tenant. This is an opinionated module that enforces good practices for DuploCloud environments. If you need to accommodate an edge case, you can implement custom ASGs with the [`duplocloud_asg_profile` resource](https://registry.terraform.io/providers/duplocloud/duplocloud/latest/docs/resources/asg_profile).
 
-## Example  
+The min/max/count is actually multiplied by the amount of zones. So if you have 3 zones and you set min=1, max=3, count=2, you will get 6 hosts.
 
-Here is a simple example used often. 
+## Example
+
+Here is a simple example used often.
 
 ```hcl
 module "nodegroup" {
@@ -20,18 +22,18 @@ module "nodegroup" {
 }
 ```
 
-## Testing  
+## Testing
 
-Run the unit tests with: 
+Run the unit tests with:
 ```sh
 terraform test -filter=tests/unit.tftests.hcl
 ```
 
-Run the integration tests with: 
+Run the integration tests with:
 ```sh
 terraform test -filter=tests/integration.tftests.hcl
 ```
 
-## References  
+## References
   - [Duploclud Hosts](https://docs.duplocloud.com/docs/azure/use-cases/hosts-vms)
   - [Duplocloud ASG](https://docs.duplocloud.com/docs/aws/use-cases/auto-scaling/auto-scaling-groups)

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -30,7 +30,7 @@ resource "duplocloud_asg_profile" "nodes" {
   max_instance_count = var.max_instance_count
   capacity           = var.capacity
   is_ebs_optimized   = var.is_ebs_optimized
-  encrypt_disk       = var.encrypt_disk
+  encrypt_disk       = true
 
   # these stay the same for autoscaling eks nodes
   agent_platform        = 7

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -70,5 +70,8 @@ resource "duplocloud_asg_profile" "nodes" {
   }
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      instance_count # Don't undo changes made by cluster autoscaler.
+    ]
   }
 }

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -35,9 +35,9 @@ resource "duplocloud_asg_profile" "nodes" {
   image_id      = data.duplocloud_native_host_image.this.image_id
 
   tenant_id          = var.tenant_id
-  instance_count     = var.instance_count
-  min_instance_count = var.min_instance_count
-  max_instance_count = var.max_instance_count
+  instance_count     = var.instance_count_per_zone
+  min_instance_count = var.min_instance_count_per_zone
+  max_instance_count = var.max_instance_count_per_zone
   capacity           = var.capacity
   is_ebs_optimized   = var.is_ebs_optimized
   encrypt_disk       = true

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -13,32 +13,16 @@ locals {
   ]
 }
 
-# discover the ami
-data "aws_ami" "eks" {
-  most_recent = true
-  owners      = ["602401143452"]
-
-  filter {
-    name   = "name"
-    values = ["${var.base_ami_name}-${var.eks_version}-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+data "duplocloud_native_host_image" "this" {
+  tenant_id     = var.tenant_id
+  is_kubernetes = true
 }
 
 resource "duplocloud_asg_profile" "nodes" {
   count         = length(var.az_list)
   zone          = count.index
   friendly_name = "${var.prefix}${var.az_list[count.index]}"
-  image_id      = data.aws_ami.eks.id
+  image_id      = data.duplocloud_native_host_image.this.image_id
 
   tenant_id          = var.tenant_id
   instance_count     = var.instance_count

--- a/modules/eks-nodes/outputs.tf
+++ b/modules/eks-nodes/outputs.tf
@@ -1,3 +1,3 @@
 output "node_ami" {
-  value = data.aws_ami.eks.id
+  value = data.duplocloud_native_host_image.this.image_id
 }

--- a/modules/eks-nodes/tests/integration.tftest.hcl
+++ b/modules/eks-nodes/tests/integration.tftest.hcl
@@ -5,7 +5,7 @@ run "make_an_asg" {
     tenant_id = "0a09ca25-7f0d-4f5f-b9fa-62290273d192"
   }
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a"
-    error_message = "friendly_name is not apps-a"
+    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-us-west-2a"
+    error_message = "friendly_name is not apps-us-west-2a"
   }
 }

--- a/modules/eks-nodes/tests/unit.tftest.hcl
+++ b/modules/eks-nodes/tests/unit.tftest.hcl
@@ -5,7 +5,7 @@ run "validate_name" {
     tenant_id = "0a09ca25-7f0d-4f5f-b9fa-62290273d192"
   }
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a"
-    error_message = "friendly_name is not apps-a"
+    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-us-west-2a"
+    error_message = "friendly_name is not apps-us-west-2a"
   }
 }

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -45,8 +45,9 @@ variable "is_ebs_optimized" {
   type    = bool
 }
 variable "encrypt_disk" {
-  default = false
-  type    = bool
+  default     = true
+  description = "Deprecated. This variable no longer has any effect. All ASGs are created with encrypted disks."
+  type        = bool
 }
 variable "minion_tags" {
   type        = map(string)

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -2,7 +2,7 @@ variable "tenant_id" {
   type = string
 }
 variable "prefix" {
-  default = ""
+  default = "eks"
   type    = string
 }
 variable "eks_version" {

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -21,7 +21,8 @@ variable "base_ami_name" {
   type        = string
 }
 variable "capacity" {
-  type = string
+  description = "Instance type."
+  type        = string
 }
 variable "instance_count_per_zone" {
   description = "Desired number of instances in each zone's ASG."

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -24,17 +24,20 @@ variable "capacity" {
   default = "t3.medium"
   type    = string
 }
-variable "instance_count" {
-  default = 1
-  type    = number
+variable "instance_count_per_zone" {
+  description = "Desired number of instances in each zone's ASG."
+  default     = 1
+  type        = number
 }
-variable "min_instance_count" {
-  default = 1
-  type    = number
+variable "min_instance_count_per_zone" {
+  description = "Minimum number of instances in each zone's ASG."
+  default     = 1
+  type        = number
 }
-variable "max_instance_count" {
-  default = 3
-  type    = number
+variable "max_instance_count_per_zone" {
+  description = "Maximum number of instances in each zone's ASG."
+  default     = 3
+  type        = number
 }
 variable "os_disk_size" {
   default = 20

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -5,21 +5,6 @@ variable "prefix" {
   default = "eks"
   type    = string
 }
-variable "eks_version" {
-  description = "Deprecated. This variable no longer has any effect. The EKS version is determined internally by the duplocloud_native_host_image resource."
-  type    = string
-  default = ""
-}
-variable "az_list" {
-  default     = []
-  type        = list(string)
-  description = "Deprecated. This variable no longer has any effect. One ASG is created for each AZ configured in the DuploCloud 'plan'."
-}
-variable "base_ami_name" {
-  description = "Deprecated. This variable no longer has any effect. The EKS AMI is found internally by the duplocloud_native_host_image resource."
-  default     = ""
-  type        = string
-}
 variable "capacity" {
   description = "Instance type."
   type        = string
@@ -43,11 +28,6 @@ variable "os_disk_size" {
 variable "is_ebs_optimized" {
   default = false
   type    = bool
-}
-variable "encrypt_disk" {
-  default     = true
-  description = "Deprecated. This variable no longer has any effect. All ASGs are created with encrypted disks."
-  type        = bool
 }
 variable "minion_tags" {
   type        = map(string)

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -6,8 +6,9 @@ variable "prefix" {
   type    = string
 }
 variable "eks_version" {
+  description = "Deprecated. This variable no longer has any effect. The EKS version is determined internally by the duplocloud_native_host_image resource."
   type    = string
-  default = "1.24"
+  default = ""
 }
 variable "az_list" {
   default     = ["a", "b"]
@@ -15,8 +16,9 @@ variable "az_list" {
   description = "The letter at the end of the zone"
 }
 variable "base_ami_name" {
-  default = "amazon-eks-node"
-  type    = string
+  description = "Deprecated. This variable no longer has any effect. The EKS AMI is found internally by the duplocloud_native_host_image resource."
+  default     = ""
+  type        = string
 }
 variable "capacity" {
   default = "t3.medium"

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -2,7 +2,7 @@ variable "tenant_id" {
   type = string
 }
 variable "prefix" {
-  default = "apps-"
+  default = ""
   type    = string
 }
 variable "eks_version" {
@@ -11,9 +11,9 @@ variable "eks_version" {
   default = ""
 }
 variable "az_list" {
-  default     = ["a", "b"]
+  default     = []
   type        = list(string)
-  description = "The letter at the end of the zone"
+  description = "Deprecated. This variable no longer has any effect. One ASG is created for each AZ configured in the DuploCloud 'plan'."
 }
 variable "base_ami_name" {
   description = "Deprecated. This variable no longer has any effect. The EKS AMI is found internally by the duplocloud_native_host_image resource."

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -21,22 +21,18 @@ variable "base_ami_name" {
   type        = string
 }
 variable "capacity" {
-  default = "t3.medium"
-  type    = string
+  type = string
 }
 variable "instance_count_per_zone" {
   description = "Desired number of instances in each zone's ASG."
-  default     = 1
   type        = number
 }
 variable "min_instance_count_per_zone" {
   description = "Minimum number of instances in each zone's ASG."
-  default     = 1
   type        = number
 }
 variable "max_instance_count_per_zone" {
   description = "Maximum number of instances in each zone's ASG."
-  default     = 3
   type        = number
 }
 variable "os_disk_size" {


### PR DESCRIPTION
The existing module wrapped `duplocloud_asg_profile` to ensure it created EKS-ready hosts. This PR tightens the wrapper to enforce things that I think are good practices for DuploCloud environments:
* Inherit the AZ list from the Plan. More or fewer ASGs than there are zones in the plan is an edge case.
* Inherit the AMI ID from the Portal. This avoids needing to keep input vars in sync with the version of the portal. As the portal is updated, the module will dynamically find new images.
* Don't expose encryption as a variable. I considered setting the default to `true`, but DuploCloud is a security-focused platform. _Disabling_ encryption at rest is such an edge case that I thought it was best to create a significant barrier.

This is definitely a debatable change, but in general I like tightly-opinionated modules. They create a standard drop-in that "just does the right thing" and leaves it to developers to handle edge cases in other ways. The underlying `duplocloud_asg_profile` is so simple that I don't think this overly burdens devs in those cases.

I've also included a few nice-to-haves that I think are unobtrusive enough to mix into the branch.

See commit messages for more details.

This isn't backwards-compatible. I thought briefly about ways to use `moved` blocks and other refinements to support that, but didn't see a clean path that didn't prevent the module from enforcing the good practices this tries to enforce. Anyone who needs to update can declare the module a second time to create new ASGs, migrate pods over to them, then remove their existing declaration to remove the old hosts. This repo is still versioned at `0.x.y`, so I didn't think backwards compatibility was essential.