### PR TITLE
Ami names asg - DUPLO-13459

### DIFF
--- a/examples/eks-nodes/main.tftest.hcl
+++ b/examples/eks-nodes/main.tftest.hcl
@@ -2,7 +2,7 @@
 run "make_an_asg" {
   command = apply
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "fun-a"
-    error_message = "friendly_name is not fun-a"
+    condition     = length(regexall("fun-a", duplocloud_asg_profile.nodes[0].friendly_name)) > 0
+    error_message = "friendly_name does not contain fun-a"
   }
 }

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -11,6 +11,7 @@ locals {
       value = v
     }
   ]
+  ami_identifier = substr(data.aws_ami.eks.id, -5, 5)
 }
 
 # discover the ami
@@ -37,7 +38,7 @@ data "aws_ami" "eks" {
 resource "duplocloud_asg_profile" "nodes" {
   count         = length(var.az_list)
   zone          = count.index
-  friendly_name = "${var.prefix}${var.az_list[count.index]}"
+  friendly_name = "${var.prefix}${var.az_list[count.index]}-${local.identifier}"
   image_id      = data.aws_ami.eks.id
 
   tenant_id          = var.tenant_id

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -38,7 +38,7 @@ data "aws_ami" "eks" {
 resource "duplocloud_asg_profile" "nodes" {
   count         = length(var.az_list)
   zone          = count.index
-  friendly_name = "${var.prefix}${var.az_list[count.index]}-${local.identifier}"
+  friendly_name = "${var.prefix}${var.az_list[count.index]}-${local.ami_identifier}"
   image_id      = data.aws_ami.eks.id
 
   tenant_id          = var.tenant_id

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -1,4 +1,5 @@
 locals {
+  ami_identifier = substr(data.aws_ami.eks.id, -5, 5)
   minion_tags = [
     for k, v in var.minion_tags : {
       key   = k
@@ -11,7 +12,6 @@ locals {
       value = v
     }
   ]
-  ami_identifier = substr(data.aws_ami.eks.id, -5, 5)
 }
 
 # discover the ami

--- a/modules/eks-nodes/tests/integration.tftest.hcl
+++ b/modules/eks-nodes/tests/integration.tftest.hcl
@@ -5,7 +5,7 @@ run "make_an_asg" {
     tenant_id = "0a09ca25-7f0d-4f5f-b9fa-62290273d192"
   }
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a"
-    error_message = "friendly_name is not apps-a"
+    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a-${local.ami_identifier}"
+    error_message = "friendly_name is not apps-a-${local.ami_identifier}"
   }
 }

--- a/modules/eks-nodes/tests/unit.tftest.hcl
+++ b/modules/eks-nodes/tests/unit.tftest.hcl
@@ -5,7 +5,7 @@ run "validate_name" {
     tenant_id = "0a09ca25-7f0d-4f5f-b9fa-62290273d192"
   }
   assert {
-    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a"
-    error_message = "friendly_name is not apps-a"
+    condition     = duplocloud_asg_profile.nodes[0].friendly_name == "apps-a-${local.ami_identifier}"
+    error_message = "friendly_name is not apps-a-${local.ami_identifier}"
   }
 }


### PR DESCRIPTION
The create before destroy isn't working as intended. Let's discuss how this can be alleviated. 

### Current Behavior:

Applying an update (new image for nodes as example) will cause the ASG to be deleted completely. All nodes in EKS are deleted. It is not until a 2nd apply is run that the ASG is recreated correctly and EKS nodes are spun up.

### Intended Behavior:
Applying an update (new image for nodes as example) causes a 2nd ASG to be spun up alongside the first one. The old ASG is spun down after the new ASG is up and (hopefully) the nodes are accepting pods.

The changes in this PR will allow differentiation of the new/old ASG so that they can exist simultaneously and allow proper transfer of workloads.