### PR TITLE
Add option to hardcode AMI

### DIFF
--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -1,5 +1,6 @@
 locals {
-  ami_identifier = substr(data.aws_ami.eks.id, -5, 5)
+  ami_identifier = substr(local.asg_ami, -5, 5)
+  asg_ami = var.asg_ami != null ? var.asg_ami : data.aws_ami.eks.id
   minion_tags = [
     for k, v in var.minion_tags : {
       key   = k
@@ -39,7 +40,7 @@ resource "duplocloud_asg_profile" "nodes" {
   count         = length(var.az_list)
   zone          = count.index
   friendly_name = "${var.prefix}${var.az_list[count.index]}-${local.ami_identifier}"
-  image_id      = data.aws_ami.eks.id
+  image_id      = local.asg_ami
 
   tenant_id          = var.tenant_id
   instance_count     = var.instance_count

--- a/modules/eks-nodes/variables.tf
+++ b/modules/eks-nodes/variables.tf
@@ -56,3 +56,8 @@ variable "metadata" {
   description = "Metadata to apply to the Duplo Minions"
   default     = {}
 }
+variable "asg_ami" {
+  default = null
+  description = "Set AMI to static value"
+  type    = string
+}


### PR DESCRIPTION
## User Description

Added the ability to set the AMI in the code to whatever value. This is needed because the automatic patching behavior is not always wanted, especially in production cases. This is unable to be turned off, as life-cycles can't be applied to modules from the outside.

## Type

Enhancement

## Current Behavior:

AMI is automatically queried based on EKS version, and the latest version of the AMI is used. This occurs on each plan and apply, and is not able to be turned off.

## Intended Behavior:

AMI is automatically queried based on EKS version, and the latest version of the AMI is used.  This can be turned off by setting the AMI via the variable `asg_ami`. This allows users to turn off the patching behavior in cases where the behavior is not wanted. Also allows setting the AMI to a specific patch/version if there are issues on newer versions.