### PR TITLE
converting numeric ownid to amazon alias

### DIFF
--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -18,7 +18,7 @@ locals {
 # discover the ami
 data "aws_ami" "eks" {
   most_recent = true
-  owners      = ["602401143452"]
+  owners      = ["amazon"]
 
   filter {
     name   = "name"


### PR DESCRIPTION
## **User description**
Amazon uses a variety of owner accounts for AMI.  This PR updates the eks owner id in the search field to use the alias "amazon", which covers all Amazon-managed accounts.  This is a blocker for deploying EKS nodes in gov-cloud.


___

## **Type**
enhancement


___

## **Description**
- Changed the AWS AMI owner ID from a specific numeric ID ("602401143452") to the alias "amazon" in the EKS nodes module. This change ensures compatibility with all Amazon-managed accounts, including those in gov-cloud, thereby removing a blocker for deploying EKS nodes in such environments.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update AWS AMI Owner ID to Alias "amazon" for EKS Nodes</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
modules/eks-nodes/main.tf

<li>Updated the AWS AMI owner ID from a specific numeric ID to the alias <br>"amazon" for EKS nodes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/6/files#diff-203d9f08c74777479f47decc5ca4e707bd15308c4bdd16e8c6a89f10726e6441">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

