### PR TITLE
Asg updates

### DIFF
--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -89,7 +89,7 @@ resource "random_integer" "identifier" {
   min = 10000
   max = 99999
   keepers = {
-    asg_ami = local.asg_ami
+    asg_ami             = local.asg_ami
     capacity            = var.capacity
     is_ebs_optimized    = var.is_ebs_optimized
     encrypt_disk        = var.encrypt_disk

--- a/modules/eks-nodes/main.tf
+++ b/modules/eks-nodes/main.tf
@@ -1,5 +1,5 @@
 locals {
-  ami_identifier = substr(local.asg_ami, -5, 5)
+  ami_identifier = random_integer.identifier.result
   asg_ami        = var.asg_ami != null ? var.asg_ami : data.aws_ami.eks.id
   minion_tags = [
     for k, v in var.minion_tags : {
@@ -82,5 +82,20 @@ resource "duplocloud_asg_profile" "nodes" {
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [instance_count]
+  }
+}
+
+resource "random_integer" "identifier" {
+  min = 10000
+  max = 99999
+  keepers = {
+    asg_ami = local.asg_ami
+    capacity            = var.capacity
+    is_ebs_optimized    = var.is_ebs_optimized
+    encrypt_disk        = var.encrypt_disk
+    use_spot_instances  = tostring(var.use_spot_instances)
+    max_spot_price      = tostring(var.max_spot_price)
+    can_scale_from_zero = var.can_scale_from_zero
+    prefix              = var.prefix
   }
 }

--- a/modules/eks-nodes/versions.tf
+++ b/modules/eks-nodes/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "duplocloud/duplocloud"
       version = ">= 0.10.24"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0"
+    }
   }
 }


### PR DESCRIPTION
Replace the last 5 digits of friendly_name from the last 5 of the AMI to a random number.
This fixes issues where the ASG has to be replaced due to changes made (spot, capacity, scale from 0, encrypting disk, etc.) but the AMI does not change. 
In cases like this, the terraform has to be run twice, due to the create_before_destroy flag causing the ASG to create on itself, then delete itself.

With new behavior, the random number will change due to keepers, changing the name of the ASG, thereby allowing the create_before_destroy flag to work correctly.