### PR TITLE
Node DNS name now changes correctly based off region

### DIFF
--- a/modules/eks-nodes/kubectl.sh
+++ b/modules/eks-nodes/kubectl.sh
@@ -5,6 +5,12 @@ DUPLO_TENANT=$2
 TIMEOUT=$3
 REGION=$(duploctl tenant region $DUPLO_TENANT | sed -E 's/.*"region": "([^"]+)".*/\1/')
 
+if [ "$REGION" = "us-east-1" ]; then
+    node_dns="ec2.internal"
+else
+   node_dns="$REGION.compute.internal"
+fi
+
 FILE="temp-$COUNT"
 if [ -e "$FILE" ]; then
     NODE_LIST="$(cat $FILE)"
@@ -19,7 +25,7 @@ if [ -e "$FILE" ]; then
         for node_ip in "${NODE_ARRAY[@]}"; do
             for sanity_ip in "${SANITY_ARRAY[@]}"; do
                 if [[ "$node_ip" == "$sanity_ip" ]]; then
-                    NODE_FMT="ip-${node_ip//./-}.$REGION.compute.internal"
+                    NODE_FMT="ip-${node_ip//./-}.$node_dns"
                     echo "kubectl draining node: $NODE_FMT"
                     kubectl drain $NODE_FMT --ignore-daemonsets --delete-emptydir-data --timeout="${TIMEOUT}s"
                 fi


### PR DESCRIPTION
### **User description**
DNS name now changes correctly based off region.


___

### **PR Type**
bug_fix


___

### **Description**
- Added logic to correctly set the DNS name for nodes based on the AWS region.
- Modified the node format string to utilize the newly set `node_dns` variable, ensuring proper DNS resolution.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubectl.sh</strong><dd><code>Fix DNS name resolution based on AWS region</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/eks-nodes/kubectl.sh

<li>Added logic to set <code>node_dns</code> based on the AWS region.<br> <li> Updated node format string to use <code>node_dns</code> variable.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/19/files#diff-c04c9c886f9e51d74ec1f9fe9d17e9d3aa929ca9fd262207f68a8699e05d1005">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information