### PR TITLE
making service_params conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
  - cert arn local did not match on govcloud cert arns
+ - service params removed for ingress resources to conflict on dns_prfx
 
 ## [0.0.37] - 2025-04-09
 

--- a/modules/loadbalancer/lbconfig.tf
+++ b/modules/loadbalancer/lbconfig.tf
@@ -21,7 +21,7 @@ resource "duplocloud_duplo_service_lbconfigs" "this" {
 }
 
 resource "duplocloud_duplo_service_params" "this" {
-  count                       = local.lbconfig_needed ? 1 : 0
+  count                       = local.lbconfig_needed && !local.is_ingress ? 1 : 0
   tenant_id                   = local.tenant.id
   replication_controller_name = var.name
   dns_prfx                    = local.dns_prfx


### PR DESCRIPTION
### **User description**
service_params and ingress conflict on dns_prefix if you create both.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes conflict between `service_params` and ingress on `dns_prefix`.

- Makes `service_params` conditional on `is_ingress`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lbconfig.tf</strong><dd><code>Fix conditional logic for `service_params` resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/loadbalancer/lbconfig.tf

<li>Updated <code>count</code> condition in <code>duplocloud_duplo_service_params</code>.<br> <li> Added check for <code>!local.is_ingress</code> to avoid conflicts.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/37/files#diff-88adfad7e7bc95693f7a7618464891612967791dc5da3c83ce65063c10472718">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>