### PR TITLE
setting external port to service listen port for ingress lbconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
  - cert arn local did not match on govcloud cert arns
  - service params removed for ingress resources to conflict on dns_prfx
+ - lbconfigs for clusterip services should use var.port as external_port instead of computed value.
 
 ## [0.0.37] - 2025-04-09
 

--- a/modules/loadbalancer/lbconfig.tf
+++ b/modules/loadbalancer/lbconfig.tf
@@ -7,7 +7,7 @@ resource "duplocloud_duplo_service_lbconfigs" "this" {
     is_native        = false
     is_internal      = var.internal
     port             = var.port
-    external_port    = local.external_port
+    external_port    = var.is_ingress ? var.port : local.external_port
     certificate_arn  = var.certificate
     protocol         = upper(var.protocol)
     health_check_url = var.health_check_url

--- a/modules/loadbalancer/lbconfig.tf
+++ b/modules/loadbalancer/lbconfig.tf
@@ -7,7 +7,7 @@ resource "duplocloud_duplo_service_lbconfigs" "this" {
     is_native        = false
     is_internal      = var.internal
     port             = var.port
-    external_port    = local.external_port
+    external_port    = local.is_ingress ? var.port : local.external_port
     certificate_arn  = var.certificate
     protocol         = upper(var.protocol)
     health_check_url = var.health_check_url

--- a/modules/loadbalancer/lbconfig.tf
+++ b/modules/loadbalancer/lbconfig.tf
@@ -7,7 +7,7 @@ resource "duplocloud_duplo_service_lbconfigs" "this" {
     is_native        = false
     is_internal      = var.internal
     port             = var.port
-    external_port    = var.is_ingress ? var.port : local.external_port
+    external_port    = local.external_port
     certificate_arn  = var.certificate
     protocol         = upper(var.protocol)
     health_check_url = var.health_check_url

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -11,8 +11,8 @@ locals {
   do_cert_lookup    = var.certificate != null && !local.cert_is_arn
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
   external_port     = (var.external_port != null ? var.external_port : 
-                      var.certificate != null ? 443 : 
-                      local.class == "service" || local.is_ingress ? var.port 
+                      local.class == "service" || local.is_ingress ? var.port :
+                      var.certificate != null ? 443 
                       : 80)
   dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
   https_redirect    = var.certificate != null ? true : false

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -11,9 +11,8 @@ locals {
   do_cert_lookup    = var.certificate != null && !local.cert_is_arn
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
   external_port     = (var.external_port != null ? var.external_port : 
-                      local.class == "service" || local.is_ingress ? var.port :
-                      var.certificate != null ? 443 
-                      : 80)
+                      var.certificate != null ? 443 :
+                      local.class == "service" ? var.port : 80)
   dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
   https_redirect    = var.certificate != null ? true : false
   ingress_annotations = local.is_ingress ? {

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -12,7 +12,8 @@ locals {
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
   external_port     = (var.external_port != null ? var.external_port : 
                       var.certificate != null ? 443 :
-                      local.class == "service" ? var.port : 80)
+                      local.class == "service" ? var.port :
+                      80)
   dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
   https_redirect    = var.certificate != null ? true : false
   ingress_annotations = local.is_ingress ? {

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -10,10 +10,7 @@ locals {
   cert_is_arn       = length(regexall("^arn:aws(-us-gov)?:acm", coalesce(var.certificate, "na"), )) > 0
   do_cert_lookup    = var.certificate != null && !local.cert_is_arn
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
-  external_port     = (var.external_port != null ? var.external_port : 
-                      var.certificate != null ? 443 :
-                      local.class == "service" ? var.port :
-                      80)
+  external_port     = var.external_port != null ? var.external_port : var.certificate != null ? 443 : local.class == "service" ? var.port : 80
   dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
   https_redirect    = var.certificate != null ? true : false
   ingress_annotations = local.is_ingress ? {

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -10,9 +10,13 @@ locals {
   cert_is_arn       = length(regexall("^arn:aws(-us-gov)?:acm", coalesce(var.certificate, "na"), )) > 0
   do_cert_lookup    = var.certificate != null && !local.cert_is_arn
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
-  external_port     = var.external_port != null ? var.external_port : var.certificate != null ? 443 : local.class == "service" ? var.port : 80
-  dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
-  https_redirect    = var.certificate != null ? true : false
+  external_port = (
+    var.external_port != null ? var.external_port :
+    var.certificate != null ? 443 :
+    local.class == "service" ? var.port :
+  80)
+  dns_prfx       = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
+  https_redirect = var.certificate != null ? true : false
   ingress_annotations = local.is_ingress ? {
     for key, value in merge(
       var.annotations,

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -10,7 +10,10 @@ locals {
   cert_is_arn       = length(regexall("^arn:aws(-us-gov)?:acm", coalesce(var.certificate, "na"), )) > 0
   do_cert_lookup    = var.certificate != null && !local.cert_is_arn
   cert_arn          = local.do_cert_lookup ? data.duplocloud_plan_certificate.this[0].arn : var.certificate
-  external_port     = var.external_port != null ? var.external_port : var.certificate != null ? 443 : local.class == "service" ? var.port : 80
+  external_port     = (var.external_port != null ? var.external_port : 
+                      var.certificate != null ? 443 : 
+                      local.class == "service" || local.is_ingress ? var.port 
+                      : 80)
   dns_prfx          = coalesce(var.dns_prfx, "${var.name}-${var.tenant}")
   https_redirect    = var.certificate != null ? true : false
   ingress_annotations = local.is_ingress ? {

--- a/modules/loadbalancer/tests/alb.tftest.hcl
+++ b/modules/loadbalancer/tests/alb.tftest.hcl
@@ -23,6 +23,14 @@ run "alb_with_cert_arn" {
     error_message = "Expected length(duplocloud_plan_certificate.this) to be 0 but got '${length(data.duplocloud_plan_certificate.this)}'"
   }
 
+  # the lbconfig should be listening on 443
+  assert {
+    condition = (
+      duplocloud_duplo_service_lbconfigs.this[0].lbconfigs[0].external_port == 443
+    )
+    error_message = "Expected external port to be 443, but got ${duplocloud_duplo_service_lbconfigs.this[0].lbconfigs[0].external_port}"
+  }
+
   # the local.cert_is_arn should be true
   assert {
     condition     = local.cert_is_arn == true

--- a/modules/loadbalancer/tests/ingress.tftest.hcl
+++ b/modules/loadbalancer/tests/ingress.tftest.hcl
@@ -8,6 +8,7 @@ run "ingress_alb" {
     tenant = "tf-tests"
     name   = "myapp"
     class  = "ingress-alb"
+    port   = "8080"
   }
 
   # assert the local.is_standalone is true
@@ -42,5 +43,11 @@ run "ingress_alb" {
       local.ingress_annotations["kubernetes.io/ingress.class"] == "alb"
     )
     error_message = "Expected local.ingress_annotations to be null"
+  }
+  assert {
+    condition = (
+      duplocloud_duplo_service_lbconfigs.this[0].lbconfigs[0].external_port == 8080
+    )
+    error_message = "Expected external port to match test port 8080, but got ${duplocloud_duplo_service_lbconfigs.this[0].lbconfigs[0].external_port}"
   }
 }


### PR DESCRIPTION
Added logic to lbconfigs to use var.port as external_port in cases where it's being used for a ClusterIP service.  Before this change, failing to pass in "external port" set to the same value as "port" resulted in ingress attempting to communicate with the ClusterIP service on the computed port (typically 80), whereas the ingress uses var.port in the rule.  This causes the target group to fail to allocate because the ingress can't find the port in the service. 

```
 Warning  FailedBuildModel        41m (x66 over 14h)  ingress  Failed build model due to ingress: namespace/ingress: unable to find port 8080 on service namespace/service
```
I attempted to do this in the existing external_port ternary but it was not a good idea because the ingress drives the creation of the LB, not the service, so disconnecting the logic at the lbconfig was necessary.  E.g, if you set external_port to port in the ternary, you end up with a load balancer attempting to listen on a nonstandard web traffic port. 