### PR TITLE
bumping required version to >=1.9.0

### DIFF
--- a/modules/configuration/versions.tf
+++ b/modules/configuration/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.4"
+  required_version = ">= 1.9.0"
   required_providers {
     duplocloud = {
       source  = "duplocloud/duplocloud"

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.4"
+  required_version = ">= 1.9.0"
   required_providers {
     duplocloud = {
       source  = "duplocloud/duplocloud"

--- a/modules/micro-service/versions.tf
+++ b/modules/micro-service/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.4"
+  required_version = ">= 1.9.0"
   required_providers {
     duplocloud = {
       source  = "duplocloud/duplocloud"


### PR DESCRIPTION
Terraform versions before 1.9.0 fail on the variable validation in the configuration and load balancer projects.  I bumped microservice, loadbalancer, and configuration since they're all typically linked.
v1.8.5:
```
│   on .terraform/modules/xapi_service/modules/configuration/variables.tf line 88, in variable "data":
│   88:       (var.data != null || var.value != null) &&
│ 
│ The condition for variable "data" can only refer to the variable itself, using var.data.
```

See https://github.com/hashicorp/terraform/issues/25609 for more detail.