### PR TITLE
adding termination grace period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added 
 
+- Added termination grace period as an option in the microservices module
 - On the micro-service module, jobs can individually override the timeouts, env vars, labels, and annotations.
 - added the following fields to nodes on the micro-service; `unique` and `spread_across_zones`
 - micro-service now outputs the follwoing fields: domain, parent_domain, image, name, namespace

--- a/modules/micro-service/service.tf
+++ b/modules/micro-service/service.tf
@@ -9,24 +9,25 @@ locals {
   }
   duplocloud_cloud = local.duplocloud_clouds[var.cloud]
   other_docker_config = yamldecode(templatefile("${path.module}/templates/service.yaml", {
-    env_from             = jsonencode(local.env_from)
-    image                = var.image
-    port                 = var.port
-    health_check         = var.health_check
-    host_network         = var.host_network
-    nodes                = var.nodes
-    restart_policy       = var.restart_policy
-    annotations          = jsonencode(var.annotations)
-    labels               = jsonencode(var.labels)
-    pod_labels           = jsonencode(var.pod_labels)
-    pod_annotations      = jsonencode(var.pod_annotations)
-    service_account_name = var.service_account_name
-    security_context     = jsonencode(var.security_context != null ? var.security_context : {})
-    volume_mounts        = jsonencode(local.volume_mounts)
-    volumes              = jsonencode(local.volumes)
-    command              = jsonencode(var.command)
-    args                 = jsonencode(var.args)
-    env                  = jsonencode(local.container_env)
+    env_from                 = jsonencode(local.env_from)
+    image                    = var.image
+    port                     = var.port
+    health_check             = var.health_check
+    host_network             = var.host_network
+    nodes                    = var.nodes
+    termination_grace_period = var.termination_grace_period
+    restart_policy           = var.restart_policy
+    annotations              = jsonencode(var.annotations)
+    labels                   = jsonencode(var.labels)
+    pod_labels               = jsonencode(var.pod_labels)
+    pod_annotations          = jsonencode(var.pod_annotations)
+    service_account_name     = var.service_account_name
+    security_context         = jsonencode(var.security_context != null ? var.security_context : {})
+    volume_mounts            = jsonencode(local.volume_mounts)
+    volumes                  = jsonencode(local.volumes)
+    command                  = jsonencode(var.command)
+    args                     = jsonencode(var.args)
+    env                      = jsonencode(local.container_env)
     resources = {
       # don't actuall print the null values
       for key, value in var.resources : key => value

--- a/modules/micro-service/templates/service.yaml
+++ b/modules/micro-service/templates/service.yaml
@@ -40,6 +40,9 @@ Volumes: ${volumes}
 %{if volume_mounts != "[]" }
 VolumesMounts: ${volume_mounts}
 %{ endif }
+%{if termination_grace_period != null }
+terminationGracePeriodSeconds: ${termination_grace_period}
+%{ endif }
 %{if health_check.enabled }
 LivenessProbe: 
   failureThreshold: ${health_check.failureThreshold}

--- a/modules/micro-service/variables.tf
+++ b/modules/micro-service/variables.tf
@@ -437,3 +437,9 @@ variable "host_network" {
   type        = bool
   default     = null
 }
+
+variable "termination_grace_period" {
+  description = "The amount of time to wait, in seconds, for pod activity to terminate gracefully after shutdown signal"
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
Adds the option to specify a terminationGracePeriod so users with special shutdown considerations can adjust the behavior.  Tested on customer dev environment - if I set the grace period, it gets populated as expected.  If I don't set it, there are no changes to the existing infra. 