### PR TITLE
incorrect ternary logic on vpc link creation

### DIFF
--- a/modules/api-gateway/rest-gateway.tf
+++ b/modules/api-gateway/rest-gateway.tf
@@ -36,7 +36,7 @@ resource "aws_api_gateway_stage" "default" {
 }
 
 resource "aws_api_gateway_vpc_link" "this" {
-  count       = var.enable_private_link ? var.type == "rest" ? 1 : 0 : 0
+  count       = var.enable_private_link && var.type == "rest" ? 1 : 0
   name        = local.fullname
   description = "Private connections for ${var.name} in ${var.tenant_name}"
   target_arns = var.vpc_link_targets

--- a/modules/api-gateway/rest-gateway.tf
+++ b/modules/api-gateway/rest-gateway.tf
@@ -36,7 +36,7 @@ resource "aws_api_gateway_stage" "default" {
 }
 
 resource "aws_api_gateway_vpc_link" "this" {
-  count       = var.enable_private_link ? var.type != "rest" ? 1 : 0 : 0
+  count       = var.enable_private_link ? var.type == "rest" ? 1 : 0 : 0
   name        = local.fullname
   description = "Private connections for ${var.name} in ${var.tenant_name}"
   target_arns = var.vpc_link_targets


### PR DESCRIPTION
aws_api_gateway_vpc_link is only compatible with REST api gateway, however the ternary logic in the resource was set to make sure type was not "rest".  Changed the logic and converted the statement to be slightly more readable.