### PR TITLE
adding index to statement_id

### DIFF
--- a/modules/api-gateway/lambda-permission.tf
+++ b/modules/api-gateway/lambda-permission.tf
@@ -1,10 +1,10 @@
 resource "duplocloud_aws_lambda_permission" "permission" {
   for_each = {
     for index, integration in local.integrations :
-    "${integration.path}/${integration.method}/${integration.name}" => integration
+    "${integration.path}/${integration.method}/${integration.name}-${index}" => merge(integration, { index = index })
   }
   tenant_id     = local.tenant_id
-  statement_id  = "AllowExecutionFromAPIGateway"
+  statement_id  = "AllowExecutionFromAPIGateway${each.value.index}"
   action        = "lambda:InvokeFunction"
   function_name = each.value.name
   principal     = "apigateway.amazonaws.com"


### PR DESCRIPTION
### **User description**
In a situation in which a single lambda services multiple endpoints, the "duplocloud_aws_lambda_permission" resource would fail on duplicate statement_ids. This change adds  the current index to the for_each map and then appends it to the statement_id to ensure it's unique.  The key constructed in the map is informative but often too long for the statement ID and using the path would run into invalid characters like { } +, etc.  While the index is not informative and could be confusing, I thought it was at least simple and robust.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix duplicate statement_id issue in lambda permissions

- Add index to ensure unique statement identifiers

- Support multiple endpoints per lambda function


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda-permission.tf</strong><dd><code>Add index to lambda permission statement_id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/api-gateway/lambda-permission.tf

<li>Add index to for_each map key to make it unique<br> <li> Merge index into integration object for access<br> <li> Append index to statement_id to prevent duplicates


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/52/files#diff-2f67eac90922ad3d38a9db347aeddc97c977030503ab5de90d8ae7938d3eafa6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>