### PR TITLE
Fix/lambda perms

### DIFF
--- a/modules/api-gateway/lambda-permission.tf
+++ b/modules/api-gateway/lambda-permission.tf
@@ -1,10 +1,10 @@
 resource "duplocloud_aws_lambda_permission" "permission" {
   for_each = {
     for index, integration in local.integrations :
-    "${integration.path}/${integration.method}/${integration.name}-${index}" => merge(integration, { index = index })
+    "${integration.path}/${integration.method}/${integration.name}-${index}" => merge(integration, { tag = substr(replace("${integration.path }${integration.method}","/[^a-zA-Z0-9]/", ""), 0, 100)})
   }
   tenant_id     = local.tenant_id
-  statement_id  = "AllowExecutionFromAPIGateway${each.value.index}"
+  statement_id  = "ExecFromAPIGW${each.value.tag}"
   action        = "lambda:InvokeFunction"
   function_name = each.value.name
   principal     = "apigateway.amazonaws.com"

--- a/modules/api-gateway/lambda-permission.tf
+++ b/modules/api-gateway/lambda-permission.tf
@@ -1,10 +1,10 @@
 resource "duplocloud_aws_lambda_permission" "permission" {
   for_each = {
     for index, integration in local.integrations :
-    "${integration.path}/${integration.method}/${integration.name}" => integration
+    "${integration.path}/${integration.method}/${integration.name}-${index}" => merge(integration, { index = index })
   }
   tenant_id     = local.tenant_id
-  statement_id  = "AllowExecutionFromAPIGateway"
+  statement_id  = "AllowExecutionFromAPIGateway${each.value.index}"
   action        = "lambda:InvokeFunction"
   function_name = each.value.name
   principal     = "apigateway.amazonaws.com"


### PR DESCRIPTION
In situations where a lambda services multiple API Gateway endpoints, the terraform would fail on duplicate SIDs.  This change implements a unique SID by appending a tag consisting of the method and path, both of which are sanitized of special characters and truncated to 100 characters.  I believe this is the best compromise of functionality, readability, and complexity.