### PR TITLE
Add configmaps variable for external configmaps

### DIFF
--- a/modules/micro-service/config.tf
+++ b/modules/micro-service/config.tf
@@ -4,9 +4,9 @@ module "configurations" {
       config.name != null ? "${config.class}/${config.name}" : config.type == "environment" ? "${config.class}/env" : "${config.class}/config"
     ) => config
   }
-  source      = "../configuration"
-  tenant_id   = local.tenant.id
-  prefix      = var.name # uses app name as prefix
+  source    = "../configuration"
+  tenant_id = local.tenant.id
+  #prefix      = var.name # uses app name as prefix
   name        = each.value.name
   enabled     = each.value.enabled
   description = each.value.description

--- a/modules/micro-service/main.tf
+++ b/modules/micro-service/main.tf
@@ -42,6 +42,12 @@ locals {
         name = secret
       }
     }
+    ], [
+    for configmap in var.config_maps : {
+      configMapRef : {
+        name = configmap
+      }
+    }
   ])
 }
 

--- a/modules/micro-service/variables.tf
+++ b/modules/micro-service/variables.tf
@@ -358,7 +358,11 @@ variable "secrets" {
   type        = list(string)
   default     = []
 }
-
+variable "config_maps" {
+  description = "The list of external configmap names to be mounted as envFrom."
+  type        = list(string)
+  default     = []
+}
 variable "configurations" {
   description = <<EOT
   A list of configurations for an application. These can be configmaps or secrets.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for external configmaps via new `config_maps` variable

- Enable mounting configmaps as envFrom in micro-service module

- Extend envFrom configuration to include configMapRef alongside existing secretRef


___

### Diagram Walkthrough


```mermaid
flowchart LR
  var["config_maps variable"]
  transform["Transform to configMapRef"]
  envFrom["envFrom locals"]
  var -- "list of names" --> transform
  transform -- "configMapRef objects" --> envFrom
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add config_maps variable definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/micro-service/variables.tf

<ul><li>Added new <code>config_maps</code> variable to accept list of external configmap <br>names<br> <li> Variable defaults to empty list for backward compatibility<br> <li> Includes descriptive documentation for the new variable</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/66/files#diff-cbefa3ea9bed0d7766c97d4031f1dd4ba95ebbd7495c307e02645216cfd5c777">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Extend envFrom with configMapRef support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/micro-service/main.tf

<ul><li>Extended envFrom locals to include configMapRef entries from <br><code>config_maps</code> variable<br> <li> Transforms each configmap name into configMapRef object structure<br> <li> Maintains consistency with existing secretRef implementation pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/66/files#diff-78437873d180bd15bb7dd53f5b1ac8bd8497da6ffc2c099e472841bb53feec1a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

