### PR TITLE
Fix external && unmanaged configMap in the `micro-service` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Fix external configmap/secret reference in micro-service module to use actual resource name instead of prefixed name.
 - Add a data-only module for DuploCloud VPNs in AWS.
 - Add a data-only module for data accessible in an AWS tenant.
 - Add support for set_ingress_health_check option so that an ingress with multiple clusterip services can have health check routes that aren't always "/" for each service.

--- a/modules/configuration/main.tf
+++ b/modules/configuration/main.tf
@@ -1,6 +1,6 @@
 locals {
   id               = var.name != null ? var.name : var.type == "environment" ? "env" : "configs"
-  name             = nonsensitive(var.prefix != null ? "${var.prefix}-${local.id}" : local.id)
+  name             = nonsensitive(var.external ? local.id : var.prefix != null ? "${var.prefix}-${local.id}" : local.id)
   realName         = nonsensitive(local.resource != null ? local.resource[local.schema.name_key] : local.name)
   data             = var.data != null ? var.data : {}
   value            = var.value != null ? var.value : jsonencode(local.data)

--- a/modules/micro-service/config.tf
+++ b/modules/micro-service/config.tf
@@ -14,7 +14,8 @@ module "configurations" {
   class       = each.value.class
   csi         = each.value.csi
   managed     = each.value.managed
+  external    = each.value.external
   mountPath   = each.value.mountPath
-  data        = each.value.data
+  data        = each.value.external ? null : each.value.data
   value       = each.value.value
 }


### PR DESCRIPTION
### **User description**
## Fix external configmap reference in micro-service module
### Summary
Enables the `external` configuration option to properly reference existing configmaps/secrets without creating new resources.
### Changes
- Pass `external` variable from micro-service module to configuration module
- Skip name prefix when `external=true` so envFrom references the actual resource name
- Set `data = null` when external to satisfy validation requirements
### Use Case
```hcl
configurations = [
  {
    name     = "my-external-configmap"
    class    = "configmap"
    external = true
    managed  = false
  }
]


___

### **PR Type**
Bug fix


___

### **Description**
- Pass `external` variable from micro-service to configuration module

- Skip name prefix when `external=true` to reference actual resource name

- Set `data=null` when external to satisfy validation requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MS["micro-service module"]
  CONFIG["configuration module"]
  EXT["external flag"]
  NAME["name handling"]
  DATA["data handling"]
  
  MS -- "passes external value" --> CONFIG
  EXT -- "when true" --> NAME
  NAME -- "skips prefix" --> CONFIG
  EXT -- "when true" --> DATA
  DATA -- "sets to null" --> CONFIG
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Conditional name prefix handling for external resources</code>&nbsp; &nbsp; </dd></summary>
<hr>

modules/configuration/main.tf

<ul><li>Modified <code>name</code> local variable to conditionally skip prefix when <br><code>external=true</code><br> <li> Uses <code>local.id</code> directly for external resources instead of prefixed name<br> <li> Preserves original naming logic for managed resources</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/67/files#diff-429ddb6c4ab539e5ad04e3c06dbcbc32b2afd1dcbfdf9f299212a3bea0325b5b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.tf</strong><dd><code>Pass external flag and conditionally set data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/micro-service/config.tf

<ul><li>Added <code>external</code> variable passed to configuration module<br> <li> Set <code>data</code> to <code>null</code> when <code>external=true</code> to avoid creating new resources<br> <li> Maintains data value for managed configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-duplocloud-components/pull/67/files#diff-732c1fb66577a058ccbfbe1a9a2d47f4b3d5af52809a0d2686ea1a8c43db56d8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

