### PR TITLE
Add HPA behavior to micro-service scale variable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		},
 		"ghcr.io/duplocloud/devcontainers/duploctl:latest": {},
 		"ghcr.io/duplocloud/devcontainers/onepassword-cli:1": {
+			"enabled": "${localEnv:OP_CLI_ENABLED}",
 			"autoSsh": "${localEnv:OP_AUTO_SSH}",
 			"sshSecretNames": "${localEnv:OP_SSH_SECRET}",
 			"vault": "${localEnv:OP_VAULT_NAME}",
@@ -15,7 +16,9 @@
 		},
 		"ghcr.io/duplocloud/devcontainers/terraform:1": {},
 		// "ghcr.io/duplocloud/devcontainers/github:latest": {},
-		"ghcr.io/duplocloud/devcontainers/ai-codex:1.0.2": {}
+		"ghcr.io/duplocloud/devcontainers/ai-codex:latest": {
+			"skills": "devcontainers,tf-module"
+		}
 	},
 	"runArgs": [
 		"--env-file=${localWorkspaceFolder}/.env"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+## Terraform DuploCloud Components — Agent Notes
+
+Purpose: repo of Terraform modules that wrap DuploCloud patterns (plus a few AWS/GitHub/MongoDB helpers). Start with `README.md`, then jump into `modules/` and `examples/`.
+
+### Where to look (quick prompts)
+- Module docs live in `modules/*/README.md`; usage examples in `examples/<module>/`.
+- If a module has no README (e.g., `modules/compose`, `modules/infrastructure`, `modules/loadbalancer`), read the module `.tf` files and check matching `examples/`.
+- `modules/api-gateway` and `modules/lambda` README content appears copy‑pasted from `modules/retool-bastion`; verify the actual module code before using.
+
+### Common module entry points (open these when relevant)
+- `modules/configuration`: configmaps/secrets/SSM/Secrets Manager.
+- `modules/context`: shared tenant context + JIT outputs.
+- `modules/eks-nodes`: HA EKS node groups + optional ASG refresh.
+- `modules/env-file`: parses env files into key/value outputs.
+- `modules/gamelift-build`: GameLift build + fleet from S3 artifact.
+- `modules/micro-service`: single Duplo service + optional LB.
+- `modules/mongodb`: MongoDB Atlas cluster/user setup.
+- `modules/retool-bastion`: bastion host for Retool ↔ private resources.
+- `modules/tenant`, `modules/tenant-*`: tenant creation + GitHub/AWS integrations.
+- `modules/tenant-data-aws`, `modules/vpn-data-aws`: data-only helpers.
+- `modules/website-gcp`: GCP website deployment.
+
+### Tests
+- Module-level tests: run inside a module dir with `tf test -filter=tests/unit.tftest.hcl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - Add support for set_ingress_health_check option so that an ingress with multiple clusterip services can have health check routes that aren't always "/" for each service.
 - Added usage example of taints for asg profile node group
 - Added taints for asg profile node group
+- Added `behavior` to the micro service `scale` variable to tune HPA scale up and scale down rates.
 
 ## [0.0.41] - 2025-07-16
 

--- a/modules/micro-service/service.tf
+++ b/modules/micro-service/service.tf
@@ -43,6 +43,7 @@ locals {
     minReplicas = var.scale.min
     maxReplicas = var.scale.max
     metrics     = local.hpa_metrics
+    behavior    = lookup(var.scale, "behavior", null)
   }))
 }
 

--- a/modules/micro-service/service.tf
+++ b/modules/micro-service/service.tf
@@ -39,11 +39,16 @@ locals {
     sidecars = var.sidecars
   }))
   hpa_metrics = lookup(var.scale, "metrics", null)
+  # only keep the directions actually configured, an empty one renders a bare yaml key which decodes to null
+  hpa_behavior = {
+    for direction, rules in var.scale.behavior : direction => rules
+    if rules.stabilizationWindowSeconds != null || rules.selectPolicy != null || length(rules.policies) > 0
+  }
   hpa_specs = yamldecode(templatefile("${path.module}/templates/hpa-spec.yaml", {
     minReplicas = var.scale.min
     maxReplicas = var.scale.max
     metrics     = local.hpa_metrics
-    behavior    = lookup(var.scale, "behavior", null)
+    behavior    = local.hpa_behavior
   }))
 }
 

--- a/modules/micro-service/templates/hpa-spec.yaml
+++ b/modules/micro-service/templates/hpa-spec.yaml
@@ -47,10 +47,9 @@ metrics:
 %{ endif }
 %{ endfor ~}
 %{ endif }
-%{ if behavior != null }
+%{ if length(behavior) > 0 }
 behavior:
 %{ for direction, rules in behavior }
-%{ if rules != null }
   ${direction}:
     %{ if rules.stabilizationWindowSeconds != null }
     stabilizationWindowSeconds: ${rules.stabilizationWindowSeconds}
@@ -58,7 +57,7 @@ behavior:
     %{ if rules.selectPolicy != null }
     selectPolicy: ${rules.selectPolicy}
     %{ endif ~}
-    %{ if rules.policies != null }
+    %{ if length(rules.policies) > 0 }
     policies:
     %{ for policy in rules.policies }
     - type: ${policy.type}
@@ -66,6 +65,5 @@ behavior:
       periodSeconds: ${policy.periodSeconds}
     %{ endfor ~}
     %{ endif ~}
-%{ endif }
 %{ endfor ~}
 %{ endif }

--- a/modules/micro-service/templates/hpa-spec.yaml
+++ b/modules/micro-service/templates/hpa-spec.yaml
@@ -47,3 +47,25 @@ metrics:
 %{ endif }
 %{ endfor ~}
 %{ endif }
+%{ if behavior != null }
+behavior:
+%{ for direction, rules in behavior }
+%{ if rules != null }
+  ${direction}:
+    %{ if rules.stabilizationWindowSeconds != null }
+    stabilizationWindowSeconds: ${rules.stabilizationWindowSeconds}
+    %{ endif ~}
+    %{ if rules.selectPolicy != null }
+    selectPolicy: ${rules.selectPolicy}
+    %{ endif ~}
+    %{ if rules.policies != null }
+    policies:
+    %{ for policy in rules.policies }
+    - type: ${policy.type}
+      value: ${policy.value}
+      periodSeconds: ${policy.periodSeconds}
+    %{ endfor ~}
+    %{ endif ~}
+%{ endif }
+%{ endfor ~}
+%{ endif }

--- a/modules/micro-service/tests/hpa.tftest.hcl
+++ b/modules/micro-service/tests/hpa.tftest.hcl
@@ -67,4 +67,166 @@ run "hpa_with_resources" {
   }
 }
 
+run "hpa_behavior_omitted" {
+  command = plan
+  variables {
+    tenant = var.tenant
+    name   = var.name
+    resources = {
+      limits = {
+        cpu    = "200m"
+        memory = "512Mi"
+      }
+    }
+    scale = {
+      min = 2
+      max = 10
+      metrics = [{
+        type = "Resource"
+        resource = {
+          name   = "cpu"
+          target = { type = "Utilization", averageUtilization = 50 }
+        }
+      }]
+    }
+  }
+
+  assert {
+    condition     = !can(local.hpa_specs.behavior)
+    error_message = "The hpa spec should have no behavior key when behavior is not given."
+  }
+}
+
+run "hpa_behavior" {
+  command = plan
+  variables {
+    tenant = var.tenant
+    name   = var.name
+    resources = {
+      limits = {
+        cpu    = "200m"
+        memory = "512Mi"
+      }
+    }
+    scale = {
+      min = 2
+      max = 10
+      metrics = [{
+        type = "Resource"
+        resource = {
+          name   = "cpu"
+          target = { type = "Utilization", averageUtilization = 50 }
+        }
+      }]
+      behavior = {
+        scaleUp = {
+          stabilizationWindowSeconds = 120
+          policies                   = [{ type = "Pods", value = 2, periodSeconds = 120 }]
+        }
+        scaleDown = {
+          stabilizationWindowSeconds = 1800
+          selectPolicy               = "Min"
+          policies                   = [{ type = "Pods", value = 1, periodSeconds = 600 }]
+        }
+      }
+    }
+  }
+
+  assert {
+    condition = (
+      local.hpa_specs.behavior.scaleUp.stabilizationWindowSeconds == 120 &&
+      length(local.hpa_specs.behavior.scaleUp.policies) == 1 &&
+      local.hpa_specs.behavior.scaleUp.policies[0].type == "Pods" &&
+      local.hpa_specs.behavior.scaleUp.policies[0].value == 2 &&
+      local.hpa_specs.behavior.scaleUp.policies[0].periodSeconds == 120
+    )
+    error_message = "The scaleUp behavior was not rendered correctly."
+  }
+
+  assert {
+    condition = (
+      local.hpa_specs.behavior.scaleDown.stabilizationWindowSeconds == 1800 &&
+      local.hpa_specs.behavior.scaleDown.selectPolicy == "Min" &&
+      local.hpa_specs.behavior.scaleDown.policies[0].periodSeconds == 600
+    )
+    error_message = "The scaleDown behavior was not rendered correctly."
+  }
+
+  assert {
+    condition     = !can(local.hpa_specs.behavior.scaleUp.selectPolicy)
+    error_message = "An unset selectPolicy should be omitted rather than rendered as null."
+  }
+}
+
+# an empty behavior, direction, or policy list should be dropped entirely so the
+# rendered spec never carries a null in place of an object or list
+run "hpa_behavior_empty" {
+  command = plan
+  variables {
+    tenant = var.tenant
+    name   = var.name
+    resources = {
+      limits = {
+        cpu    = "200m"
+        memory = "512Mi"
+      }
+    }
+    scale = {
+      min = 2
+      max = 10
+      metrics = [{
+        type = "Resource"
+        resource = {
+          name   = "cpu"
+          target = { type = "Utilization", averageUtilization = 50 }
+        }
+      }]
+      behavior = {
+        scaleUp = { policies = [] }
+      }
+    }
+  }
+
+  assert {
+    condition     = !can(local.hpa_specs.behavior)
+    error_message = "A behavior with no effective values should be omitted from the hpa spec."
+  }
+}
+
+run "hpa_behavior_one_direction" {
+  command = plan
+  variables {
+    tenant = var.tenant
+    name   = var.name
+    resources = {
+      limits = {
+        cpu    = "200m"
+        memory = "512Mi"
+      }
+    }
+    scale = {
+      min = 2
+      max = 10
+      metrics = [{
+        type = "Resource"
+        resource = {
+          name   = "cpu"
+          target = { type = "Utilization", averageUtilization = 50 }
+        }
+      }]
+      behavior = {
+        scaleDown = { stabilizationWindowSeconds = 900 }
+      }
+    }
+  }
+
+  assert {
+    condition = (
+      local.hpa_specs.behavior.scaleDown.stabilizationWindowSeconds == 900 &&
+      !can(local.hpa_specs.behavior.scaleUp)
+    )
+    error_message = "Only the configured direction should be present in the behavior block."
+  }
+}
+
 

--- a/modules/micro-service/variables.tf
+++ b/modules/micro-service/variables.tf
@@ -79,6 +79,8 @@ variable "scale" {
   This includes the replicas, min, max, and the metrics for determining how to auto scale.
 
   The metrics field is a list of metrics to use for autoscaling. Auto scaling is considered `enabled` when there are metrics, if there are none then the service will only use the replica count. See [Kubernetes Horizontal Pod Autoscale Walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) for more information.
+
+  The behavior field tunes how quickly the autoscaler reacts, using the scaleUp and scaleDown blocks of the HPA behavior spec. It only takes effect when metrics are set. See [Configurable scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior).
   EOT
   type = object({
     replicas = optional(number, null)
@@ -125,6 +127,26 @@ variable "scale" {
         })
       }))
     })))
+    behavior = optional(object({
+      scaleUp = optional(object({
+        stabilizationWindowSeconds = optional(number)
+        selectPolicy               = optional(string)
+        policies = optional(list(object({
+          type          = string
+          value         = number
+          periodSeconds = number
+        })))
+      }))
+      scaleDown = optional(object({
+        stabilizationWindowSeconds = optional(number)
+        selectPolicy               = optional(string)
+        policies = optional(list(object({
+          type          = string
+          value         = number
+          periodSeconds = number
+        })))
+      }))
+    }))
   })
   default = {}
 }

--- a/modules/micro-service/variables.tf
+++ b/modules/micro-service/variables.tf
@@ -135,8 +135,8 @@ variable "scale" {
           type          = string
           value         = number
           periodSeconds = number
-        })))
-      }))
+        })), [])
+      }), {})
       scaleDown = optional(object({
         stabilizationWindowSeconds = optional(number)
         selectPolicy               = optional(string)
@@ -144,9 +144,9 @@ variable "scale" {
           type          = string
           value         = number
           periodSeconds = number
-        })))
-      }))
-    }))
+        })), [])
+      }), {})
+    }), {})
   })
   default = {}
 }


### PR DESCRIPTION
## Summary

The micro-service module's `scale` variable only supported `replicas`/`min`/`max`/`metrics`, so the generated HPA spec never included a `behavior` block. The underlying `duplocloud_duplo_service` resource already accepts the full HPA spec, so this just exposes the lever that was already there.

This came out of a request to slow down scale-down and add a scale-up stabilization window for short-lived traffic spikes — previously the only workaround was setting it out-of-band in the UI, which the next apply would revert.

## Changes

- `variables.tf` — optional `behavior` object on `var.scale`, with `scaleUp`/`scaleDown`, each taking `stabilizationWindowSeconds`, `selectPolicy`, and a list of `policies` (`type`/`value`/`periodSeconds`).
- `service.tf` — passes `behavior` into the HPA template.
- `templates/hpa-spec.yaml` — renders the `behavior` block, skipping nulls, matching the file's existing conditional style.
- `CHANGELOG.md` — entry under Unreleased.

## Usage

```hcl
scale = {
  min = 2
  max = 10
  metrics = [{
    type     = "Resource"
    resource = {
      name   = "cpu"
      target = { type = "Utilization", averageUtilization = 70 }
    }
  }]
  behavior = {
    scaleUp = {
      stabilizationWindowSeconds = 120
      policies = [{ type = "Pods", value = 2, periodSeconds = 120 }]
    }
    scaleDown = {
      stabilizationWindowSeconds = 1800
      selectPolicy               = "Min"
      policies = [{ type = "Pods", value = 1, periodSeconds = 600 }]
    }
  }
}
```

## Testing

Rendered the template through `templatefile` + `yamldecode` with the config above and confirmed the output matches the intended HPA spec exactly. With `behavior` unset the rendered spec is byte-identical to the pre-change output, so **existing callers get no diff on their next apply**. `terraform validate` passes and `terraform fmt -check` is clean.

## Notes

- `behavior` rides on `hpa_specs`, which is only sent when `metrics != null` — the same gate as today. A service with `behavior` but no metrics will silently drop it. That matches how HPA works (no autoscaler, nothing to tune), but it fails quietly rather than erroring.
- README variable docs weren't regenerated — flagging in case terraform-docs regen is expected here.
- This branch also carries some unrelated devcontainer/AGENTS.md devex changes that were already in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)